### PR TITLE
Add Fetch Data history

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const visualizationContainer = document.getElementById('visualization-container');
     const tableContainer = document.getElementById('table-container');
     const loadingIndicator = document.getElementById('loading');
-    
+    const historyList = document.getElementById('history-list');
+    const clearHistoryBtn = document.getElementById('clear-history');
+
     // Visualization type buttons
     const lineChartBtn = document.getElementById('line-chart');
     const scatterChartBtn = document.getElementById('scatter-chart');
@@ -21,10 +23,14 @@ document.addEventListener('DOMContentLoaded', () => {
     
     // Store fetched data
     let fetchedData = [];
+    let fetchHistory = [];
     
     // Add event listeners
     addVectorBtn.addEventListener('click', addVectorInput);
     fetchDataBtn.addEventListener('click', fetchData);
+    clearHistoryBtn.addEventListener('click', clearHistory);
+
+    loadHistory();
     
     // Visualization type event listeners
     lineChartBtn.addEventListener('click', () => changeVisualization('line'));
@@ -165,7 +171,52 @@ document.addEventListener('DOMContentLoaded', () => {
         } finally {
             // Hide loading indicator
             loadingIndicator.classList.add('hidden');
+            saveToHistory(requestData);
         }
+    }
+
+    function saveToHistory(requestData) {
+        const entry = {
+            timestamp: new Date().toISOString(),
+            requestData
+        };
+        fetchHistory.push(entry);
+        localStorage.setItem('fetchHistory', JSON.stringify(fetchHistory));
+        updateHistoryList();
+    }
+
+    function loadHistory() {
+        const stored = localStorage.getItem('fetchHistory');
+        if (stored) {
+            try {
+                fetchHistory = JSON.parse(stored);
+            } catch (e) {
+                fetchHistory = [];
+            }
+        }
+        updateHistoryList();
+    }
+
+    function updateHistoryList() {
+        historyList.innerHTML = '';
+        if (fetchHistory.length === 0) {
+            const li = document.createElement('li');
+            li.textContent = 'No history yet';
+            historyList.appendChild(li);
+            return;
+        }
+        fetchHistory.forEach(entry => {
+            const li = document.createElement('li');
+            const vectors = entry.requestData.map(r => `${r.vectorId}(${r.latestN})`).join(', ');
+            li.textContent = `${new Date(entry.timestamp).toLocaleString()}: ${vectors}`;
+            historyList.appendChild(li);
+        });
+    }
+
+    function clearHistory() {
+        fetchHistory = [];
+        localStorage.removeItem('fetchHistory');
+        updateHistoryList();
     }
     
     // Function to change visualization type
@@ -175,7 +226,8 @@ document.addEventListener('DOMContentLoaded', () => {
         
         // Update active button
         document.querySelectorAll('.viz-btn').forEach(btn => btn.classList.remove('active'));
-        document.getElementById(`${type}-chart`) || document.getElementById(`${type}-view`).classList.add('active');
+        const activeBtn = document.getElementById(`${type}-chart`) || document.getElementById(`${type}-view`);
+        if (activeBtn) activeBtn.classList.add('active');
         
         // Update visualization if we have data
         if (fetchedData.length > 0) {

--- a/index.html
+++ b/index.html
@@ -30,15 +30,20 @@
                 
                 <div class="visualization-controls">
                     <h3>Visualization Type</h3>
-                    <div class="viz-buttons">
-                        <button id="line-chart" class="viz-btn active">Line</button>
-                        <button id="scatter-chart" class="viz-btn">Scatter</button>
-                        <button id="bar-chart" class="viz-btn">Bar</button>
-                        <button id="table-view" class="viz-btn">Table</button>
-                    </div>
+                <div class="viz-buttons">
+                    <button id="line-chart" class="viz-btn active">Line</button>
+                    <button id="scatter-chart" class="viz-btn">Scatter</button>
+                    <button id="bar-chart" class="viz-btn">Bar</button>
+                    <button id="table-view" class="viz-btn">Table</button>
                 </div>
             </div>
+            <div class="history-section">
+                <h3>Request History</h3>
+                <ul id="history-list"></ul>
+                <button id="clear-history" class="btn danger">Clear History</button>
+            </div>
         </div>
+    </div>
         
         <div class="main-content">
             <h1>Statistics Canada Data Visualizer</h1>

--- a/styles.css
+++ b/styles.css
@@ -206,3 +206,25 @@ th {
 .remove-vector:hover {
     opacity: 0.9;
 }
+
+.btn.danger {
+    background-color: var(--danger-color);
+    color: white;
+}
+
+.history-section {
+    margin-top: 20px;
+}
+
+.history-section ul {
+    list-style: disc;
+    padding-left: 20px;
+    max-height: 150px;
+    overflow-y: auto;
+    margin-bottom: 10px;
+}
+
+.history-section li {
+    margin-bottom: 4px;
+    font-size: 0.9rem;
+}


### PR DESCRIPTION
## Summary
- implement a simple fetch request history stored in localStorage
- display history in a new sidebar section with a clear button
- style the new history list and button
- fix visualization button active class logic

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6870b081b854832387df0191c92bd2b0