### PR TITLE
Fix log modal usability

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,6 +37,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const logModal = document.getElementById('log-modal');
     const logList = document.getElementById('log-list');
     const closeLogBtn = document.getElementById('close-log');
+
+    // Disable log button until at least one fetch is logged
+    showLogBtn.disabled = true;
     
     // Current visualization type
     let currentVizType = 'line';
@@ -84,6 +87,20 @@ document.addEventListener('DOMContentLoaded', () => {
 
     showLogBtn.addEventListener('click', openLogModal);
     closeLogBtn.addEventListener('click', () => logModal.classList.add('hidden'));
+
+    // Close modal when clicking outside the content
+    logModal.addEventListener('click', (e) => {
+        if (e.target === logModal) {
+            logModal.classList.add('hidden');
+        }
+    });
+
+    // Close modal on Escape key press
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') {
+            logModal.classList.add('hidden');
+        }
+    });
     
     // Function to add a new vector input
     function addVectorInput() {
@@ -193,6 +210,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ request: requestData })
                 });
+                // Log stored successfully, enable log button
+                showLogBtn.disabled = false;
             } catch (e) {
                 console.error('Failed to log request', e);
             }

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
                 
                 <button id="add-vector" class="btn">Add Vector</button>
                 <button id="fetch-data" class="btn primary">Fetch Data</button>
-                <button id="show-log" class="btn">Show Log</button>
+                <button id="show-log" class="btn" disabled>Show Log</button>
                 
                 <div class="visualization-controls">
                     <h3>Chart Type</h3>

--- a/styles.css
+++ b/styles.css
@@ -306,3 +306,9 @@ th {
 .re-fetch:hover {
     opacity: 0.9;
 }
+
+/* Disabled button styles */
+button:disabled, .btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}


### PR DESCRIPTION
## Summary
- disable "Show Log" button until at least one request is logged
- allow closing the log modal via Escape key or clicking outside
- visually style disabled buttons

## Testing
- `npm run dev` *(fails: `netlify: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68766b34e6c48323bf281bbcb12dc4a1